### PR TITLE
Vibration and IMU enabled by default

### DIFF
--- a/Assets/RumbleData.asset
+++ b/Assets/RumbleData.asset
@@ -13,11 +13,11 @@ MonoBehaviour:
   m_Name: RumbleData
   m_EditorClassIdentifier: 
   profile:
-    highBandFrequencyLeft: 320
-    highBandAmplitudeLeft: 0
-    lowBandFrequencyLeft: 160
-    lowBandAmplitudeLeft: 0
+    highBandFrequencyLeft: 569
+    highBandAmplitudeLeft: 0.562
+    lowBandFrequencyLeft: 309
+    lowBandAmplitudeLeft: 0.453
     highBandFrequencyRight: 320
-    highBandAmplitudeRight: 0
+    highBandAmplitudeRight: 0.218
     lowBandFrequencyRight: 160
-    lowBandAmplitudeRight: 0
+    lowBandAmplitudeRight: 0.421

--- a/Packages/com.canopteks.switchcontrollerinput/Editor/EditorWindow/DeviceDebugWindow.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Editor/EditorWindow/DeviceDebugWindow.cs
@@ -108,17 +108,12 @@ namespace SwitchControllerInput.Editor
 
                     readIMU = EditorGUILayout.Toggle("Fast-frequency display: ", readIMU);
 
-                    if (GUILayout.Button("Enable IMU"))
-                    {
-                        controller.SetIMUEnabled(true);
-                    }
-
                     //* Little button for debug/dev purposes
                     // EditorGUILayout.Separator();
                     // GUILayout.Label("Debug: ", EditorStyles.boldLabel);
-                    // if (GUILayout.Button("Tst"))
+                    // if (GUILayout.Button("Test"))
                     // {
-                    //     //
+                    //     
                     // }
                 }
 

--- a/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerHID.cs
+++ b/Packages/com.canopteks.switchcontrollerinput/Runtime/HID/SwitchControllerHID.cs
@@ -100,6 +100,7 @@ namespace UnityEngine.InputSystem.Switch
         private bool m_deviceInfoLoaded = false;
         private bool m_colorsLoaded = false;
         private bool m_serialNumberLoaded = false;
+        private bool m_defaultLEDsSet = false;
 
         // Register the time of last request to retry to fetch them in case of timeout
         private double m_IMUConfigTimeOfLastRequest;
@@ -108,6 +109,7 @@ namespace UnityEngine.InputSystem.Switch
         private double m_infoTimeOfLastRequest;
         private double m_colorsTimeOfLastRequest;
         private double m_serialNumberTimeOfLastRequest;
+        private double m_defaultLEDsSetTimeOfLastRequest;
 
         // Timeout vars
         private const int configTimerDataDefault = 500;
@@ -236,6 +238,11 @@ namespace UnityEngine.InputSystem.Switch
                 UpdateIMUEnabled();
                 return;
             }
+            if(!m_defaultLEDsSet)
+            {
+                UpdateDefaultLEDs();
+                return;
+            }
         }
 
         /// <summary>
@@ -309,6 +316,22 @@ namespace UnityEngine.InputSystem.Switch
             {
                 m_IMUConfigTimeOfLastRequest = currentTime;
                 SetIMUEnabled(true);
+            }
+        }
+
+        private void UpdateDefaultLEDs()
+        {
+            double currentTime = InputRuntime.s_Instance.currentTime;
+
+            if (currentTime > m_defaultLEDsSetTimeOfLastRequest + timeout)
+            {
+                m_defaultLEDsSetTimeOfLastRequest = currentTime;
+                SetLEDs(
+                    p1: LEDStatusEnum.On,
+                    p2: LEDStatusEnum.Off,
+                    p3: LEDStatusEnum.Off,
+                    p4: LEDStatusEnum.Off
+                );
             }
         }
         #endregion
@@ -560,6 +583,9 @@ namespace UnityEngine.InputSystem.Switch
                     case SubcommandIDEnum.EnableDisableIMU:
                         HandleIMUEnabled();
                         break;
+                    case SubcommandIDEnum.SetPlayerLights:
+                        HandleLEDsSet();
+                        break;
                     default:
                         break;
                 }
@@ -582,6 +608,15 @@ namespace UnityEngine.InputSystem.Switch
         {
             // Allows to stop trying to enable it on startup
             m_IMUConfigDataLoaded = true;
+        }
+
+        /// <summary>
+        /// Handle the subcommand response to a user trying to set the LEDs
+        /// </summary>
+        private void HandleLEDsSet()
+        {
+            // Allows to stop trying to enable them on startup
+            m_defaultLEDsSet = true;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ General data about the connected Switch controllers can be found in the menu `Wi
 - Left and right analog sticks and stick presses
   - **Note**: Although they use the factory configuration/calibration info, they still seem to have significant drift
 
-### HD Rumble: WIP
+### HD Rumble
 
 High-band and low-band amplitude and frequency for the left and right Joy-Cons (or, in the case of the Pro Controller, the left and right sides of the controller) can be set with the `SwitchControllerHID.Rumble()` method.
 
@@ -61,11 +61,11 @@ var rumbleProfile = new SwitchControllerRumbleProfile
 controller.Rumble(rumbleProfile);
 ```
 
-The HD Rumble features can be tested `Windows/Switch Controller Debugger/Joycon Rumble Playground`
+The HD Rumble features can be tested with `Windows/Switch Controller Debugger/Joycon Rumble Playground`, or in the inspector when selecting a `RumbleDataSheet` scriptable object instance.
 
 ### Gyroscope and acceleration (partial)
 
-Once the controller's IMU has been enabled with `SwitchControllerHID.SetIMUEnabled(true)`, it will report uncalibrated acceleration and gyroscope data. In my testing, this data isn't particularly accurate, so we should figure out how to improve it.
+Report uncalibrated acceleration and gyroscope data. In my testing, this data isn't particularly accurate, so we should figure out how to improve it.
 
 ### Player LEDs
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ The green LEDs on the controllers can be set with `SwitchControllerHID.SetLEDs()
 Example:
 ```c#
 controller.SetLEDs(
-    p1: SwitchControllerLEDStatusEnum.Off,
-    p2: SwitchControllerLEDStatusEnum.On,
-    p3: SwitchControllerLEDStatusEnum.Flashing,
-    p4: SwitchControllerLEDStatusEnum.On
+    p1: LEDStatusEnum.Off,
+    p2: LEDStatusEnum.On,
+    p3: LEDStatusEnum.Flashing,
+    p4: LEDStatusEnum.On
     );
 ```
 


### PR DESCRIPTION
- Set the vibration as enabled by default on startup;
- Same with the IMU (= gyroscope and acceleration) data reports;
- Set the LEDs as: first on, others off; by default so they stop blinking.